### PR TITLE
Add `index.html` to report URL for static hosting compatibility; minor README and action.yml updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Could be published on the GitHub Pages or any other static web server.
 
 ## Usage
 
-### Checkout git hub pages
+### Checkout GitHub Pages
 
 Skip this step if you don't need test history in your Allure report.
 
-If your github pages are in default `gh-pages` branch, to checkout them to
+If your GitHub Pages are in default `gh-pages` branch, to checkout them to
 folder `gh-pages-dir` use:
 
 ```yaml
-    - name: Checkout github pages with previous Allure reports
-      uses: actions/checkout@v4
-      continue-on-error: true
-      with:
-        ref: gh-pages
-        path: gh-pages-dir
+- name: Checkout GitHub Pages with previous Allure reports
+  uses: actions/checkout@v4
+  continue-on-error: true
+  with:
+    ref: gh-pages
+    path: gh-pages-dir
 ```
 
 The `continue-on-error: true` flag prevents workflow failure if no previous reports exist.
@@ -45,38 +45,37 @@ For Python projects:
 This is where we need the action.
 
 ```yaml
-    - name: Generate Allure test report
-      uses: andgineer/allure-report@v3.5
-      id: allure-report
-      if: always()
-      with:
-        allure-results: allure-results
-        website: gh-pages-dir
-        reports-site-path: builds/tests
+- name: Generate Allure test report
+  uses: andgineer/allure-report@v3.5
+  id: allure-report
+  if: always()
+  with:
+    allure-results: allure-results
+    website: gh-pages-dir
+    reports-site-path: builds/tests
 ```
 
 `website` is the directory with our website.
 
 `reports-site-path` is where the reports located in the website, empty if in root.
 
-The Allure report will be created inplace in the `website` / `reports-site-path`, in separate folder named as 
-github run number.
+The Allure report will be created inplace in the `website` / `reports-site-path`, in separate folder named after the GitHub workflow run number.
 
 In the root of `website` / `reports-site-path` will be created `index.html` that auto-redirect to the last report.
 
 Note we use `if: always()` to create report even if the tests failed.
 
-### Publish the report back to the github pages
+### Publish the report back to the GitHub Pages
 
 ```yaml
-    - name: Publish Allure test report
-      uses: peaceiris/actions-gh-pages@v3
-      if: ${{ always() && (steps.allure-report.outcome == 'success') }}
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_branch: gh-pages
-        publish_dir: ${{ steps.allure-report.outputs.reports-site }}
-        destination_dir: ${{ steps.allure-report.outputs.reports-site-path }}
+- name: Publish Allure test report
+  uses: peaceiris/actions-gh-pages@v3
+  if: ${{ always() && (steps.allure-report.outcome == 'success') }}
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    publish_branch: gh-pages
+    publish_dir: ${{ steps.allure-report.outputs.reports-site }}
+    destination_dir: ${{ steps.allure-report.outputs.reports-site-path }}
 ```
 
 We use outputs of the previous step so no need to copy&past your paths.
@@ -100,44 +99,44 @@ This action uses Docker and is compatible only with Linux runners.
 
 ### Inputs
 
-| Name        | Description                                                                                                                                           | Default                                                                 |
-|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| allure-results | Allure test result directory created by tests.                                                                                                        | allure-results                                                          |
-| website     | Website directory (e.g., checkouted from the gh-pages branch).                                                                                        | gh-pages-dir                                                            |
+| Name              | Description                                                                                                                                           | Default                                                                 |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| allure-results    | Allure test result directory created by tests.                                                                                                        | allure-results                                                          |
+| website           | Website directory (e.g., checkouted from the gh-pages branch).                                                                                        | gh-pages-dir                                                            |
 | reports-site-path | Allure report path within the website.                                                                                                                | builds/tests                                                            |
-| reports-site | Allure reports directory, to be pushed to the website repository at the `reports-site-path`. If specified the old reports copied here from `website`. | [create report inplace in `website`/`reports-site-path`]                |
-| report-page | Allure report page to be opened by default with the output `report-url` (graphs, timeline, behaviors etc)                                             | behaviors                                                               |
-| website-url | Custom URL to use instead of the default GitHub Pages URL for the website where Allure report will be published                                       |                                                                         |
-| report-name | The name to be shown on top of the Overview tab in the Allure report                                                                                  | Allure Test Report                                                      |
-| ci-name     | The name of the CI server                                                                                                                             | GitHub Action: {{ env.github_workflow }}                                |
-| max-reports | Number of previous Allure reports to keep. Set to 0 to keep all reports.                                                                              | 20                                                                      |
-| summary     | Summary text for the action to be shown in the GitHub Actions UI. Set to empty string to disable.                                                     | \n## Test report\n[Allure test report]({{ outputs["REPORT_URL"] }})\n\n |
+| reports-site      | Allure reports directory, to be pushed to the website repository at the `reports-site-path`. If specified the old reports copied here from `website`. | [create report inplace in `website`/`reports-site-path`]                |
+| report-page       | Allure report page to be opened by default with the output `report-url` (graphs, timeline, behaviors etc)                                             | behaviors                                                               |
+| website-url       | Custom URL to use instead of the default GitHub Pages URL for the website where Allure report will be published                                       |                                                                         |
+| report-name       | The name to be shown on top of the Overview tab in the Allure report                                                                                  | Allure Test Report                                                      |
+| ci-name           | The name of the CI server                                                                                                                             | GitHub Action: {{ env.github_workflow }}                                |
+| max-reports       | Number of previous Allure reports to keep. Set to 0 to keep all reports.                                                                              | 20                                                                      |
+| summary           | Summary text for the action to be shown in the GitHub Actions UI. Set to empty string to disable.                                                     | \n## Test report\n[Allure test report]({{ outputs["REPORT_URL"] }})\n\n |
 
 ### Outputs
 
-| Name              | Description                                                                              | 
-|-------------------|------------------------------------------------------------------------------------------|
-| report-url        | URL of the created report                                                                | 
+| Name              | Description                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| report-url        | URL of the created report                                                                |
 | reports-root-url  | Root of all reports with index.html that auto-redirect to the last report                |
-| reports-site-path | Copy of input reports-site-path                      |
-| reports-site | Folder where the reports located. To be published in `reports-site-path` in your website |
+| reports-site-path | Copy of input reports-site-path                                                          |
+| reports-site      | Folder where the reports located. To be published in `reports-site-path` in your website |
 
 ## Working details
 
-Report is generated from [Allure results](https://allurereport.org/docs/how-it-works/) 
+Report is generated from [Allure results](https://allurereport.org/docs/how-it-works/)
 folder specified in `allure-results`.
 
-Read the Allure docs to know how to create them. 
-For example, in Python, you can use `allure-pytest` package. 
-It adds to `pytest` option `--alluredir`. 
+Read the Allure docs to know how to create them.
+For example, in Python, you can use `allure-pytest` package.
+It adds to `pytest` option `--alluredir`.
 So to generate Allure results in `allure-pytest`, use `pytest --alluredir=./allure-results`.
 
 History reports expected in `website` / `reports-site-path`.
 
-If `allure-report` is specified, the history reports is copied to it and the new report generated in it. 
+If `allure-report` is specified, the history reports is copied to it and the new report generated in it.
 Otherwise, the report is generated inplace in the `website` / `reports-site-path`.
 
-Each report is stored in folder with the github run number.
+Each report is stored in a unique folder named after the GitHub workflow run number.
 
 In the root of the reports folder the action creates `index.html` with redirect to the last report.
 
@@ -156,7 +155,7 @@ For formatting and linting install pre-commit hooks:
 Tests uses local docker-compose to run the action.
 It sets env vars like in Github action environment (from `tests/resources/.env` file)
 
-   python -m pytest tests/
+python -m pytest tests/
 
 You can run the action in the Docker locally with:
 
@@ -168,8 +167,9 @@ for experiments inside the container use:
     inv container
 
 All the commands
-    
+
     inv --list
 
 ## Coverage report
-* [Coveralls](https://coveralls.io/github/andgineer/allure-report)
+
+- [Coveralls](https://coveralls.io/github/andgineer/allure-report)

--- a/action.yml
+++ b/action.yml
@@ -1,68 +1,59 @@
-name: 'generate-allure-report'
-description: 'Generate Allure Report'
-author: 'Andrey Sorokin'
+name: "generate-allure-report"
+description: "Generate Allure Report"
+author: "Andrey Sorokin"
 branding:
-  icon: 'bar-chart'
-  color: 'yellow'
+  icon: "bar-chart"
+  color: "yellow"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 inputs:
   allure-results:
-    description: 'Allure test result directory created by tests.'
+    description: "Allure test result directory created by tests."
     required: true
-    default: 'allure-results'
+    default: "allure-results"
   website:
-    description: 'Website directory (e.g., checkouted from the gh-pages branch).'
+    description: "Website directory (e.g., checkouted from the gh-pages branch)."
     required: true
-    default: 'gh-pages-dir'
+    default: "gh-pages-dir"
   reports-site-path:
-    description: 'Allure report path within the website.'
+    description: "Allure report path within the website."
     required: false
-    default: 'builds/tests'
+    default: "builds/tests"
   reports-site:
-    description: 'Allure reports directory, to be pushed to the website repository at the `reports-site-path`. Each report on the subfolder with the github run number. If specified the old reports copied from `website`. By default create report inplace in `website`/`reports-site-path`.'
+    description: "Allure reports directory, to be pushed to the website repository at the `reports-site-path`. Each report on the subfolder with the github run number. If specified the old reports copied from `website`. By default create report inplace in `website`/`reports-site-path`."
     required: true
-    default: ''
+    default: ""
   website-url:
-    description: 'Custom URL to use instead of the default GitHub Pages URL for the website where Allure report will be published'
+    description: "Custom URL to use instead of the default GitHub Pages URL for the website where Allure report will be published"
     required: false
-    default: ''
+    default: ""
   report-page:
-    description: 'Allure report page to be opened by default with the output `report-url`'
-    default: 'behaviors'
+    description: "Allure report page to be opened by default with the output `report-url`"
+    default: "behaviors"
     required: true
-    type: choice
-    options:
-      - overview
-      - categories
-      - suites
-      - graphs
-      - timeline
-      - behaviors
-      - packages
   report-name:
-    description: 'The name to be shown on top of the Overview tab in the Allure report'
+    description: "The name to be shown on top of the Overview tab in the Allure report"
     required: false
-    default: 'Allure Test Report'
+    default: "Allure Test Report"
   ci-name:
-    description: 'The name of the CI server'
+    description: "The name of the CI server"
     required: false
-    default: 'GitHub Action: {{ env.github_workflow }}'
+    default: "GitHub Action: {{ env.github_workflow }}"
   max-reports:
-    description: 'Number of previous Allure reports to keep. Set to 0 to keep all reports.'
+    description: "Number of previous Allure reports to keep. Set to 0 to keep all reports."
     required: false
-    default: 20
+    default: "20"
   summary:
-    description: 'Summary text for the action to be shown in the GitHub Actions UI. Set to empty string to disable.'
+    description: "Summary text for the action to be shown in the GitHub Actions UI. Set to empty string to disable."
     required: false
     default: '\n## Test report\n[Allure test report]({{ outputs["report-url"] }})\n\n'
 outputs:
   report-url:
-    description: 'URL to the Allure report'
+    description: "URL to the Allure report"
   reports-site-path:
-    description: 'Copy of input reports-site-path'
+    description: "Copy of input reports-site-path"
   reports-site:
-    description: 'Folder where the reports located. To be published in `reports-site-path` in your website'
+    description: "Folder where the reports located. To be published in `reports-site-path` in your website"
   reports-root-url:
-    description: 'Root of all reports with index.html that auto-redirect to the last report'
+    description: "Root of all reports with index.html that auto-redirect to the last report"

--- a/src/allure_generate.py
+++ b/src/allure_generate.py
@@ -101,7 +101,7 @@ class AllureGenerator(ActionBase):  # type: ignore  # pylint: disable=too-many-i
         self.generate_allure_report()
         self.cleanup_reports()
         self.create_index_html()
-        self.outputs.report_url = f"{self.last_report_folder_url}index.html{self.report_page()}"
+        self.outputs.report_url = f"{self.last_report_folder_url}{self.report_page()}"
         self.outputs.reports_root_url = self.root_url
         self.outputs.reports_site_path = self.inputs.reports_site_path
         self.outputs.reports_site = self.reports_site
@@ -149,7 +149,7 @@ class AllureGenerator(ActionBase):  # type: ignore  # pylint: disable=too-many-i
     @cached_property
     def last_report_folder_url(self) -> str:
         """Get URL to the last report."""
-        return "/".join([self.root_url, self.env.github_run_number]) + "/"
+        return "/".join([self.root_url, self.env.github_run_number]) + "/index.html"
 
     def report_page(self) -> str:
         """Get the report page part of the url."""
@@ -159,7 +159,7 @@ class AllureGenerator(ActionBase):  # type: ignore  # pylint: disable=too-many-i
         """Create index.html in the report folder root with redirect to the last report."""
         template = self.environment.get_template("index.html")
         rendered_template = template.render(
-            url=f"{self.last_report_folder_url}index.html{self.report_page()}"
+            url=f"{self.last_report_folder_url}{self.report_page()}"
         )
         (self.reports_site / "index.html").write_text(rendered_template)
 

--- a/src/allure_generate.py
+++ b/src/allure_generate.py
@@ -101,7 +101,7 @@ class AllureGenerator(ActionBase):  # type: ignore  # pylint: disable=too-many-i
         self.generate_allure_report()
         self.cleanup_reports()
         self.create_index_html()
-        self.outputs.report_url = f"{self.last_report_folder_url}{self.report_page()}"
+        self.outputs.report_url = f"{self.last_report_file_url}{self.report_page()}"
         self.outputs.reports_root_url = self.root_url
         self.outputs.reports_site_path = self.inputs.reports_site_path
         self.outputs.reports_site = self.reports_site
@@ -147,7 +147,7 @@ class AllureGenerator(ActionBase):  # type: ignore  # pylint: disable=too-many-i
         return url
 
     @cached_property
-    def last_report_folder_url(self) -> str:
+    def last_report_file_url(self) -> str:
         """Get URL to the last report."""
         return "/".join([self.root_url, self.env.github_run_number]) + "/index.html"
 
@@ -158,9 +158,7 @@ class AllureGenerator(ActionBase):  # type: ignore  # pylint: disable=too-many-i
     def create_index_html(self) -> None:
         """Create index.html in the report folder root with redirect to the last report."""
         template = self.environment.get_template("index.html")
-        rendered_template = template.render(
-            url=f"{self.last_report_folder_url}{self.report_page()}"
-        )
+        rendered_template = template.render(url=f"{self.last_report_file_url}{self.report_page()}")
         (self.reports_site / "index.html").write_text(rendered_template)
 
     def generate_allure_report(self) -> None:
@@ -168,7 +166,7 @@ class AllureGenerator(ActionBase):  # type: ignore  # pylint: disable=too-many-i
         template = self.environment.get_template("executor.json")
         # https://allurereport.org/docs/how-it-works-executor-file/
         rendered_template = template.render(
-            report_url=self.last_report_folder_url,
+            report_url=self.last_report_file_url,
             report_name=self.render(self.inputs.report_name),
             ci_name=self.render(self.inputs.ci_name),
             github_run_number=self.env.github_run_number,

--- a/tests/resources/executor.json
+++ b/tests/resources/executor.json
@@ -2,7 +2,7 @@
     "name": "GitHub Action: CI/CD",
     "type": "github",
     "reportName": "Allure Report",
-    "reportUrl": "https://owner.github.io/repo/builds/tests/1/",
+    "reportUrl": "https://owner.github.io/repo/builds/tests/1/index.html",
     "buildUrl": "https://github.com/owner/repo/actions/runs/1",
     "buildName": "GitHub Actions Run #1",
     "buildOrder": "1"


### PR DESCRIPTION
This PR modifies the `last_report_folder_url()` function to explicitly append `index.html` to the generated report URL. This change ensures compatibility with some static hosting environments like JFrog Artifactory, which do not automatically serve `index.html` when accessing a directory URL (e.g., `/`).

Without this addition, navigating to the report root may return a directory listing (example below) or an error instead of the expected HTML report.
<p align="center"> <img src="https://github.com/user-attachments/assets/6472920e-a561-49fc-9aaa-0b6b49829c1d" alt="Directory Listing Example" width="500"/> </p>

Additional changes:
- Minor improvements to the `README.md` for clarity and formatting
- Updated `action.yml` to align with GitHub Actions specification